### PR TITLE
fix build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}") 
+		classpath('io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE')
 	}
 }
 


### PR DESCRIPTION
add `classpath('io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE')`  to fix build error ;
 > Failed to apply plugin [class 'io.spring.gradle.dependencymanagement.DependencyManagementPlugin']
Could not create task of type 'DependencyManagementReportTask'.